### PR TITLE
Add support for date time types

### DIFF
--- a/src/main/kotlin/de/smartsquare/socketio/emitter/packers/MapPacker.kt
+++ b/src/main/kotlin/de/smartsquare/socketio/emitter/packers/MapPacker.kt
@@ -4,6 +4,9 @@ import de.smartsquare.socketio.emitter.Message
 import de.smartsquare.socketio.emitter.Metadata
 import org.msgpack.core.MessagePack
 import java.io.ByteArrayOutputStream
+import java.text.SimpleDateFormat
+import java.time.temporal.Temporal
+import java.util.Date
 
 internal class MapPacker {
 
@@ -31,6 +34,8 @@ internal class MapPacker {
                     is Double -> it.packDouble(value)
                     is Long -> it.packLong(value)
                     is Boolean -> it.packBoolean(value)
+                    is Date -> it.packString(SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS").format(value))
+                    is Temporal -> it.packString(value.toString())
                     else -> error("The type of $key is not implemented yet. Feel free to open a pull request.")
                 }
             }

--- a/src/main/kotlin/de/smartsquare/socketio/emitter/packers/MapPacker.kt
+++ b/src/main/kotlin/de/smartsquare/socketio/emitter/packers/MapPacker.kt
@@ -7,8 +7,16 @@ import java.io.ByteArrayOutputStream
 import java.text.SimpleDateFormat
 import java.time.temporal.Temporal
 import java.util.Date
+import java.util.TimeZone
 
 internal class MapPacker {
+
+    private companion object {
+        @JvmStatic
+        private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS").apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+    }
 
     fun pack(message: Message.MapMessage, metadata: Metadata): ByteArray {
         val packerStream = ByteArrayOutputStream()
@@ -34,7 +42,7 @@ internal class MapPacker {
                     is Double -> it.packDouble(value)
                     is Long -> it.packLong(value)
                     is Boolean -> it.packBoolean(value)
-                    is Date -> it.packString(SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS").format(value))
+                    is Date -> it.packString(dateFormat.format(value))
                     is Temporal -> it.packString(value.toString())
                     else -> error("The type of $key is not implemented yet. Feel free to open a pull request.")
                 }

--- a/src/test/kotlin/de/smartsquare/socketio/emitter/EmitterTests.kt
+++ b/src/test/kotlin/de/smartsquare/socketio/emitter/EmitterTests.kt
@@ -10,6 +10,12 @@ import org.junit.jupiter.api.assertThrows
 import org.msgpack.core.MessagePack
 import redis.clients.jedis.Jedis
 import redis.clients.jedis.JedisPool
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.util.Date
 
 class EmitterTests {
 
@@ -119,6 +125,31 @@ class EmitterTests {
 
         val encoded = MessagePack.newDefaultUnpacker(pubSlot.captured).unpackValue().toString()
         encoded shouldEqual """["emitter",{"type":2,"data":["topic",{"name":"deen","age":23,"height":1.9}],"nsp":"/"},{"rooms":[],"except":[],"flags":{}}]"""
+    }
+
+    @Test
+    fun `publish json message with date times`() {
+        val publisher = Emitter(jedisPool)
+
+        val date = Date(1577836861001)
+        val localDateTime = LocalDateTime.of(2021, 1, 1, 1, 1, 1, 1)
+        val offsetDateTime = OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC)
+        val zonedDateTime = ZonedDateTime.of(2021, 1, 1, 1, 1, 1, 1, ZoneId.of("Etc/UTC"))
+
+        publisher.broadcast(
+            Message.MapMessage(
+                "topic",
+                mapOf(
+                    "date" to date,
+                    "localDateTime" to localDateTime,
+                    "offsetDateTime" to offsetDateTime,
+                    "zonedDateTime" to zonedDateTime
+                )
+            )
+        )
+
+        val encoded = MessagePack.newDefaultUnpacker(pubSlot.captured).unpackValue().toString()
+        encoded shouldEqual """["emitter",{"type":2,"data":["topic",{"date":"2020-01-01T01:01:01.001","localDateTime":"2021-01-01T01:01:01.000000001","offsetDateTime":"2021-01-01T01:01:01.000000001Z","zonedDateTime":"2021-01-01T01:01:01.000000001Z[Etc/UTC]"}],"nsp":"/"},{"rooms":[],"except":[],"flags":{}}]"""
     }
 
     @Test

--- a/src/test/kotlin/de/smartsquare/socketio/emitter/EmitterTests.kt
+++ b/src/test/kotlin/de/smartsquare/socketio/emitter/EmitterTests.kt
@@ -131,7 +131,7 @@ class EmitterTests {
     fun `publish json message with date times`() {
         val publisher = Emitter(jedisPool)
 
-        val date = Date(1609459261001)
+        val date = Date(1609462861001)
         val localDateTime = LocalDateTime.of(2021, 1, 1, 1, 1, 1, 1)
         val offsetDateTime = OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC)
         val zonedDateTime = ZonedDateTime.of(2021, 1, 1, 1, 1, 1, 1, ZoneId.of("Etc/UTC"))

--- a/src/test/kotlin/de/smartsquare/socketio/emitter/EmitterTests.kt
+++ b/src/test/kotlin/de/smartsquare/socketio/emitter/EmitterTests.kt
@@ -131,7 +131,7 @@ class EmitterTests {
     fun `publish json message with date times`() {
         val publisher = Emitter(jedisPool)
 
-        val date = Date(1577836861001)
+        val date = Date(1609459261001)
         val localDateTime = LocalDateTime.of(2021, 1, 1, 1, 1, 1, 1)
         val offsetDateTime = OffsetDateTime.of(2021, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC)
         val zonedDateTime = ZonedDateTime.of(2021, 1, 1, 1, 1, 1, 1, ZoneId.of("Etc/UTC"))
@@ -149,7 +149,7 @@ class EmitterTests {
         )
 
         val encoded = MessagePack.newDefaultUnpacker(pubSlot.captured).unpackValue().toString()
-        encoded shouldEqual """["emitter",{"type":2,"data":["topic",{"date":"2020-01-01T01:01:01.001","localDateTime":"2021-01-01T01:01:01.000000001","offsetDateTime":"2021-01-01T01:01:01.000000001Z","zonedDateTime":"2021-01-01T01:01:01.000000001Z[Etc/UTC]"}],"nsp":"/"},{"rooms":[],"except":[],"flags":{}}]"""
+        encoded shouldEqual """["emitter",{"type":2,"data":["topic",{"date":"2021-01-01T01:01:01.001","localDateTime":"2021-01-01T01:01:01.000000001","offsetDateTime":"2021-01-01T01:01:01.000000001Z","zonedDateTime":"2021-01-01T01:01:01.000000001Z[Etc/UTC]"}],"nsp":"/"},{"rooms":[],"except":[],"flags":{}}]"""
     }
 
     @Test


### PR DESCRIPTION
This makes it possible to serialize `Date`s and everything that extends `Temporal` (e.g. `Instant` and `LocalDateTime`). The values are converted to the ISO 8601 string representation.