### PR TITLE
Abstract away jedis using RedisPublisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ repositories {
 }
 
 dependencies {
-    implementation "de.smartsquare:socket-io-redis-emitter:0.11.3"   
+    implementation "de.smartsquare:socket-io-redis-emitter:0.11.3"
 }
 ```
 
@@ -46,10 +46,8 @@ This library comes with a default implementation for both jedis and lettuce.
 
 ### Emit Cheatsheet
 
-When using Jedis:
 ```kotlin
-val jedisConnection = jedisConnectionFactory.connection as JedisConnection
-val emitter = Emitter(JedisPublisher(jedisConnection.jedis))
+val emitter = Emitter(JedisPublisher(jedis))
 
 // Publishing a simple text message
 emitter.broadcast(topic = "something", value = "Hello World!")
@@ -82,6 +80,18 @@ emitter.broadcast(topic = "something", value = "Hello World!")
 The [example](example) directory contains a working docker-compose setup which can be started
 using `docker-compose --compatibility up`. The setup contains one redis instance, one java publisher, three
 socket.io-servers and three consuming socket.io-clients.
+
+### Usage in Spring Boot and Jedis
+
+Jedis:
+```kotlin
+@Bean
+fun emitter(redisConnectionFactory: RedisConnectionFactory): Emitter {
+    val jedisConnectionFactory = redisConnectionFactory as JedisConnectionFactory
+    val jedisConnection = jedisConnectionFactory.connection as JedisConnection
+    return Emitter(JedisPublisher(jedisConnection.jedis))
+}
+```
 
 ## :warning: Limitations
 

--- a/README.md
+++ b/README.md
@@ -38,14 +38,18 @@ repositories {
 }
 
 dependencies {
-    implementation "de.smartsquare:socket-io-redis-emitter:0.11.3"
+    implementation "de.smartsquare:socket-io-redis-emitter:0.11.3"   
 }
 ```
 
+This library comes with a default implementation for both jedis and lettuce.
+
 ### Emit Cheatsheet
 
+When using Jedis:
 ```kotlin
-val emitter = Emitter(JedisPool("localhost"), namespace = "/")
+val jedisConnection = jedisConnectionFactory.connection as JedisConnection
+val emitter = Emitter(JedisPublisher(jedisConnection.jedis))
 
 // Publishing a simple text message
 emitter.broadcast(topic = "something", value = "Hello World!")

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ buildscript {
         kotlinVersion = "1.5.10"
         detektVersion = "1.17.1"
         ktlintVersion = "10.1.0"
-        jedisVersion = "3.6.1"
         mockkVersion = "1.11.0"
         kluentVersion = "1.66"
         msgpackVersion = "0.9.0"
@@ -36,7 +35,7 @@ plugins {
 }
 
 group = "de.smartsquare"
-version = System.getenv("GITHUB_VERSION") ?: "1.0.0-SNAPSHOT"
+version = System.getenv("GITHUB_VERSION") ?: "1.0.1-SNAPSHOT"
 description = "Library to emit socket.io notifications via redis."
 
 repositories {
@@ -44,7 +43,6 @@ repositories {
 }
 
 dependencies {
-    api "redis.clients:jedis:$jedisVersion"
     api "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
 
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ plugins {
 }
 
 group = "de.smartsquare"
-version = System.getenv("GITHUB_VERSION") ?: "1.0.1-SNAPSHOT"
+version = System.getenv("GITHUB_VERSION") ?: "1.0.0-SNAPSHOT"
 description = "Library to emit socket.io notifications via redis."
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,8 @@ buildscript {
         byteBuddyVersion = "1.11.1"
         gradleNexusVersion = "1.1.0"
         gradleVersionsVersion = "0.39.0"
+        jedisVersion = "4.4.3"
+        lettuceVersion = "6.2.6.RELEASE"
     }
 
     configurations.classpath {
@@ -59,8 +61,12 @@ dependencies {
     testImplementation "org.amshove.kluent:kluent:$kluentVersion"
     testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
     testImplementation "org.skyscreamer:jsonassert:$jsonAssertVersion"
+    testImplementation "redis.clients:jedis:$jedisVersion"
 
     testRuntimeOnly "net.bytebuddy:byte-buddy:$byteBuddyVersion"
+
+    compileOnly "redis.clients:jedis:$jedisVersion"
+    compileOnly "io.lettuce:lettuce-core:$lettuceVersion"
 }
 
 java {
@@ -180,12 +186,12 @@ nexusPublishing {
     }
 }
 
-signing {
-    def signingKey = findProperty("signingKey") ?: System.getenv("GPG_PRIVATE_KEY")
-    def signingPassword = findProperty("signingPassword") ?: System.getenv("GPG_PASSPHRASE")
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign publishing.publications.mavenJava
-}
+//signing {
+//    def signingKey = findProperty("signingKey") ?: System.getenv("GPG_PRIVATE_KEY")
+//    def signingPassword = findProperty("signingPassword") ?: System.getenv("GPG_PASSPHRASE")
+//    useInMemoryPgpKeys(signingKey, signingPassword)
+//    sign publishing.publications.mavenJava
+//}
 
 wrapper {
     gradleVersion = project.ext.gradleVersion

--- a/build.gradle
+++ b/build.gradle
@@ -186,12 +186,12 @@ nexusPublishing {
     }
 }
 
-//signing {
-//    def signingKey = findProperty("signingKey") ?: System.getenv("GPG_PRIVATE_KEY")
-//    def signingPassword = findProperty("signingPassword") ?: System.getenv("GPG_PASSPHRASE")
-//    useInMemoryPgpKeys(signingKey, signingPassword)
-//    sign publishing.publications.mavenJava
-//}
+signing {
+    def signingKey = findProperty("signingKey") ?: System.getenv("GPG_PRIVATE_KEY")
+    def signingPassword = findProperty("signingPassword") ?: System.getenv("GPG_PASSPHRASE")
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign publishing.publications.mavenJava
+}
 
 wrapper {
     gradleVersion = project.ext.gradleVersion

--- a/src/main/kotlin/de/smartsquare/socketio/emitter/Emitter.kt
+++ b/src/main/kotlin/de/smartsquare/socketio/emitter/Emitter.kt
@@ -21,9 +21,9 @@ class Emitter @JvmOverloads constructor(
         val payload = messageConverter.convert(SocketIoMessage(id, topic, value, namespace, rooms, except))
 
         if (rooms.size == 1) {
-            redisPublisher.publish("socket.io#$namespace#${rooms.first()}#".toByteArray(), payload)
+            redisPublisher.publish("socket.io#$namespace#${rooms.first()}#", payload)
         } else {
-            redisPublisher.publish("socket.io#$namespace#".toByteArray(), payload)
+            redisPublisher.publish("socket.io#$namespace#", payload)
         }
     }
 }

--- a/src/main/kotlin/de/smartsquare/socketio/emitter/JedisPublisher.kt
+++ b/src/main/kotlin/de/smartsquare/socketio/emitter/JedisPublisher.kt
@@ -1,0 +1,9 @@
+package de.smartsquare.socketio.emitter
+
+import redis.clients.jedis.Jedis
+
+class JedisPublisher(private val jedis: Jedis) : RedisPublisher {
+    override fun publish(channel: String, message: ByteArray) {
+        jedis.use { it.publish(channel.toByteArray(), message) }
+    }
+}

--- a/src/main/kotlin/de/smartsquare/socketio/emitter/LettucePublisher.kt
+++ b/src/main/kotlin/de/smartsquare/socketio/emitter/LettucePublisher.kt
@@ -1,0 +1,9 @@
+package de.smartsquare.socketio.emitter
+
+import io.lettuce.core.api.StatefulRedisConnection
+
+class LettucePublisher(private val connection: StatefulRedisConnection<Any, Any>) : RedisPublisher {
+    override fun publish(channel: String, message: ByteArray) {
+        connection.use { it.sync().publish(channel, message.decodeToString()) }
+    }
+}

--- a/src/main/kotlin/de/smartsquare/socketio/emitter/RedisPublisher.kt
+++ b/src/main/kotlin/de/smartsquare/socketio/emitter/RedisPublisher.kt
@@ -1,0 +1,5 @@
+package de.smartsquare.socketio.emitter
+
+interface RedisPublisher {
+    fun publish(channel: ByteArray, message: ByteArray)
+}

--- a/src/main/kotlin/de/smartsquare/socketio/emitter/RedisPublisher.kt
+++ b/src/main/kotlin/de/smartsquare/socketio/emitter/RedisPublisher.kt
@@ -1,5 +1,5 @@
 package de.smartsquare.socketio.emitter
 
 interface RedisPublisher {
-    fun publish(channel: ByteArray, message: ByteArray)
+    fun publish(channel: String, message: ByteArray)
 }

--- a/src/test/kotlin/de/smartsquare/socketio/emitter/EmitterTest.kt
+++ b/src/test/kotlin/de/smartsquare/socketio/emitter/EmitterTest.kt
@@ -3,12 +3,9 @@ package de.smartsquare.socketio.emitter
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import io.mockk.verify
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 import org.msgpack.core.MessagePack
-import redis.clients.jedis.Jedis
-import redis.clients.jedis.JedisPool
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneId
@@ -21,17 +18,13 @@ class EmitterTest {
     private val topicSlot = slot<ByteArray>()
     private val pubSlot = slot<ByteArray>()
 
-    private val jedis = mockk<Jedis>(relaxed = true) {
-        every { publish(capture(topicSlot), capture(pubSlot)) } answers { 1 }
-    }
-
-    private val jedisPool = mockk<JedisPool> {
-        every { resource } returns jedis
+    private val publisher = mockk<RedisPublisher>(relaxed = true) {
+        every { publish(capture(topicSlot), capture(pubSlot)) } answers {}
     }
 
     @Test
     fun `publish string message`() {
-        val publisher = Emitter(jedisPool)
+        val publisher = Emitter(publisher)
 
         publisher.broadcast("topic", "some very long message message message message")
 
@@ -59,17 +52,8 @@ class EmitterTest {
     }
 
     @Test
-    fun `emitter releases the resource`() {
-        val publisher = Emitter(jedisPool)
-
-        publisher.broadcast("topic", "some very long message message message message")
-
-        verify(exactly = 1) { jedis.close() }
-    }
-
-    @Test
     fun `customize emitter id`() {
-        val publisher = Emitter(jedisPool, "backend-1")
+        val publisher = Emitter(publisher, "backend-1")
 
         publisher.broadcast("topic", "some very long message message message message")
 
@@ -98,7 +82,7 @@ class EmitterTest {
 
     @Test
     fun `publish empty message`() {
-        val publisher = Emitter(jedisPool)
+        val publisher = Emitter(publisher)
 
         publisher.broadcast("topic", "")
 
@@ -127,7 +111,7 @@ class EmitterTest {
 
     @Test
     fun `publish message in namespace`() {
-        val publisher = Emitter(jedisPool, namespace = "mynamespace")
+        val publisher = Emitter(publisher, namespace = "mynamespace")
 
         publisher.broadcast("topic", "some message")
 
@@ -156,7 +140,7 @@ class EmitterTest {
 
     @Test
     fun `publish message to a room`() {
-        val publisher = Emitter(jedisPool)
+        val publisher = Emitter(publisher)
 
         publisher.broadcast("topic", "some message", rooms = listOf("myroom"))
 
@@ -190,7 +174,7 @@ class EmitterTest {
 
     @Test
     fun `publish message to two rooms exclusively`() {
-        val publisher = Emitter(jedisPool)
+        val publisher = Emitter(publisher)
 
         publisher.broadcast("topic", "some message", rooms = listOf("a", "b"))
 
@@ -225,7 +209,7 @@ class EmitterTest {
 
     @Test
     fun `publish message to all rooms except one`() {
-        val publisher = Emitter(jedisPool)
+        val publisher = Emitter(publisher)
 
         publisher.broadcast("topic", "some message", except = listOf("a"))
 
@@ -256,7 +240,7 @@ class EmitterTest {
 
     @Test
     fun `publish json message including only primitives`() {
-        val publisher = Emitter(jedisPool)
+        val publisher = Emitter(publisher)
 
         publisher.broadcast("topic", mapOf("name" to "deen", "age" to 23, "height" to 1.9))
 
@@ -289,7 +273,7 @@ class EmitterTest {
 
     @Test
     fun `publish json message with date times`() {
-        val publisher = Emitter(jedisPool)
+        val publisher = Emitter(publisher)
 
         val date = Date(1609462861001)
         val localDateTime = LocalDateTime.of(2021, 1, 1, 1, 1, 1, 1)
@@ -302,8 +286,8 @@ class EmitterTest {
                 "date" to date,
                 "localDateTime" to localDateTime,
                 "offsetDateTime" to offsetDateTime,
-                "zonedDateTime" to zonedDateTime
-            )
+                "zonedDateTime" to zonedDateTime,
+            ),
         )
 
         val encoded = MessagePack.newDefaultUnpacker(pubSlot.captured).unpackValue().toString()


### PR DESCRIPTION
Using Spring Boot 3.x, Jedis is no longer the default implementation. To support the users choice of redis client, this PR will remove the direct dependency to jedis. Instead we inverse the dependency by providing the `RedisPublisher` interface, that should be implemented by the user of the emitter.
**QUESTION:** Testing it I wrapped Springs RedisConnection in a class implementing RedisPublisher. But this way we only use one connection. What happens if the connection fails? It won't reconnect in this case I guess.