### PR TITLE
Use JedisPool instead of connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,14 @@ socket.io-servers and three consuming socket.io-clients.
 
 ### Usage in Spring Boot and Jedis
 
-Jedis:
+We don't want to rely on the Spring Data Redis abstractions in this project.
+Unfortunately, this makes it necessary that you configure the `JedisPool` manually in your Spring Boot application.
+Having JedisPool configured, the emitter can be created as follows:
+
 ```kotlin
 @Bean
-fun emitter(redisConnectionFactory: RedisConnectionFactory): Emitter {
-    val jedisConnectionFactory = redisConnectionFactory as JedisConnectionFactory
-    val jedisConnection = jedisConnectionFactory.connection as JedisConnection
-    return Emitter(JedisPublisher(jedisConnection.jedis))
+fun emitter(jedisPool: JedisPool): Emitter {
+    return Emitter(JedisPublisher(jedisPool))
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ repositories {
 }
 
 dependencies {
-    implementation "de.smartsquare:socket-io-redis-emitter:0.12.0"
+    implementation "de.smartsquare:socket-io-redis-emitter:0.13.0"
 }
 ```
 

--- a/src/main/kotlin/de/smartsquare/socketio/emitter/JedisPublisher.kt
+++ b/src/main/kotlin/de/smartsquare/socketio/emitter/JedisPublisher.kt
@@ -1,9 +1,9 @@
 package de.smartsquare.socketio.emitter
 
-import redis.clients.jedis.Jedis
+import redis.clients.jedis.JedisPool
 
-class JedisPublisher(private val jedis: Jedis) : RedisPublisher {
+class JedisPublisher(private val jedisPool: JedisPool) : RedisPublisher {
     override fun publish(channel: String, message: ByteArray) {
-        jedis.use { it.publish(channel.toByteArray(), message) }
+        jedisPool.resource.use { it.publish(channel.toByteArray(), message) }
     }
 }

--- a/src/test/kotlin/de/smartsquare/socketio/emitter/EmitterTest.kt
+++ b/src/test/kotlin/de/smartsquare/socketio/emitter/EmitterTest.kt
@@ -8,6 +8,7 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 import org.msgpack.core.MessagePack
 import redis.clients.jedis.Jedis
+import redis.clients.jedis.JedisPool
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneId
@@ -20,11 +21,15 @@ class EmitterTest {
     private val topicSlot = slot<ByteArray>()
     private val pubSlot = slot<ByteArray>()
 
+    private val jedisPool = mockk<JedisPool>(relaxed = true) {
+        every { resource } answers { jedis }
+    }
+
     private val jedis = mockk<Jedis>(relaxed = true) {
         every { publish(capture(topicSlot), capture(pubSlot)) } answers { 1 }
     }
 
-    private val jedisPublisher = JedisPublisher(jedis)
+    private val jedisPublisher = JedisPublisher(jedisPool)
 
     @Test
     fun `publish string message`() {


### PR DESCRIPTION
`.use()`ing the connection closes it when its finished, thus leaving us with a dead connection. We need to have access to the pool, so we can obtain new connections and release them within the scope of the emitter.