### PR TITLE
Add support for Spring Data and update Lettuce support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ dependencies {
 }
 ```
 
-This library comes with a default implementation for both jedis and lettuce.
+This library comes with a default implementation
+for [Jedis](https://github.com/redis/jedis),[Lettuce](https://lettuce.io/)
+and [Spring Data Redis](https://spring.io/projects/spring-data-redis/).
 
 ### Emit Cheatsheet
 
@@ -80,19 +82,6 @@ emitter.broadcast(topic = "something", value = "Hello World!")
 The [example](example) directory contains a working docker-compose setup which can be started
 using `docker-compose --compatibility up`. The setup contains one redis instance, one java publisher, three
 socket.io-servers and three consuming socket.io-clients.
-
-### Usage in Spring Boot and Jedis
-
-We don't want to rely on the Spring Data Redis abstractions in this project.
-Unfortunately, this makes it necessary that you configure the `JedisPool` manually in your Spring Boot application.
-Having JedisPool configured, the emitter can be created as follows:
-
-```kotlin
-@Bean
-fun emitter(jedisPool: JedisPool): Emitter {
-    return Emitter(JedisPublisher(jedisPool))
-}
-```
 
 ## :warning: Limitations
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@ buildscript {
         gradleVersionsVersion = "0.47.0"
         jedisVersion = "4.4.3"
         lettuceVersion = "6.2.6.RELEASE"
+        springDataVersion = "2.7.18"
+        testcontainersVersion= "1.19.3"
+        testcontainersRedisVersion= "2.0.1"
     }
 
     configurations.classpath {
@@ -61,12 +64,18 @@ dependencies {
     testImplementation "org.amshove.kluent:kluent:$kluentVersion"
     testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
     testImplementation "org.skyscreamer:jsonassert:$jsonAssertVersion"
+    testImplementation "org.testcontainers:junit-jupiter:$testcontainersVersion"
+    testImplementation "com.redis:testcontainers-redis:$testcontainersRedisVersion"
+
     testImplementation "redis.clients:jedis:$jedisVersion"
+    testImplementation "io.lettuce:lettuce-core:$lettuceVersion"
+    testImplementation "org.springframework.boot:spring-boot-starter-data-redis:$springDataVersion"
 
     testRuntimeOnly "net.bytebuddy:byte-buddy:$byteBuddyVersion"
 
     compileOnly "redis.clients:jedis:$jedisVersion"
     compileOnly "io.lettuce:lettuce-core:$lettuceVersion"
+    compileOnly "org.springframework.boot:spring-boot-starter-data-redis:$springDataVersion"
 }
 
 java {

--- a/src/main/kotlin/de/smartsquare/socketio/emitter/LettucePublisher.kt
+++ b/src/main/kotlin/de/smartsquare/socketio/emitter/LettucePublisher.kt
@@ -1,9 +1,9 @@
 package de.smartsquare.socketio.emitter
 
-import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.sync.RedisCommands
 
-class LettucePublisher(private val connection: StatefulRedisConnection<Any, Any>) : RedisPublisher {
+class LettucePublisher(private val commands: RedisCommands<String, String>) : RedisPublisher {
     override fun publish(channel: String, message: ByteArray) {
-        connection.use { it.sync().publish(channel, message.decodeToString()) }
+        commands.publish(channel, message.decodeToString())
     }
 }

--- a/src/main/kotlin/de/smartsquare/socketio/emitter/SpringDataPublisher.kt
+++ b/src/main/kotlin/de/smartsquare/socketio/emitter/SpringDataPublisher.kt
@@ -1,0 +1,9 @@
+package de.smartsquare.socketio.emitter
+
+import org.springframework.data.redis.core.RedisTemplate
+
+class SpringDataPublisher(private val redisTemplate: RedisTemplate<String, String>) : RedisPublisher {
+    override fun publish(channel: String, message: ByteArray) {
+        redisTemplate.execute({ it.publish(channel.toByteArray(), message) }, true)
+    }
+}

--- a/src/test/kotlin/de/smartsquare/socketio/emitter/JedisPublisherTest.kt
+++ b/src/test/kotlin/de/smartsquare/socketio/emitter/JedisPublisherTest.kt
@@ -1,0 +1,65 @@
+package de.smartsquare.socketio.emitter
+
+import com.redis.testcontainers.RedisContainer
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import redis.clients.jedis.JedisPool
+import redis.clients.jedis.JedisPubSub
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+@Testcontainers
+class JedisPublisherTest {
+
+    @Container
+    private val redis = RedisContainer("redis:6-alpine")
+
+    private lateinit var pool: JedisPool
+
+    @BeforeEach
+    fun setUp() {
+        pool = JedisPool(redis.redisURI)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        pool.close()
+    }
+
+    @Test
+    fun `publish string message`() {
+        val publisher = Emitter(JedisPublisher(pool))
+
+        val countDownLatch = CountDownLatch(1)
+
+        val listener = object : JedisPubSub() {
+            override fun onMessage(channel: String, message: String) {
+                channel shouldBeEqualTo "socket.io#/#"
+                message shouldContain "test 123"
+
+                countDownLatch.countDown()
+            }
+        }
+
+        val executor = Executors.newSingleThreadExecutor()
+        val jedis = pool.resource
+
+        try {
+            executor.submit { jedis.subscribe(listener, "socket.io#/#") }
+
+            publisher.broadcast("topic", "test 123")
+
+            countDownLatch.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        } finally {
+            listener.unsubscribe()
+            executor.shutdown()
+        }
+    }
+}

--- a/src/test/kotlin/de/smartsquare/socketio/emitter/LettucePublisherTest.kt
+++ b/src/test/kotlin/de/smartsquare/socketio/emitter/LettucePublisherTest.kt
@@ -1,0 +1,60 @@
+package de.smartsquare.socketio.emitter
+
+import com.redis.testcontainers.RedisContainer
+import io.lettuce.core.RedisClient
+import io.lettuce.core.pubsub.RedisPubSubAdapter
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@Testcontainers
+class LettucePublisherTest {
+
+    @Container
+    private val redis = RedisContainer("redis:6-alpine")
+
+    private lateinit var client: RedisClient
+
+    @BeforeEach
+    fun setUp() {
+        client = RedisClient.create(redis.redisURI)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        client.close()
+    }
+
+    @Test
+    fun `publish string message`() {
+        val connection = client.connect().sync()
+        val publisher = Emitter(LettucePublisher(connection))
+
+        val countDownLatch = CountDownLatch(1)
+
+        val listener = object : RedisPubSubAdapter<String, String>() {
+            override fun message(channel: String, message: String) {
+                channel shouldBeEqualTo "socket.io#/#"
+                message shouldContain "test 123"
+
+                countDownLatch.countDown()
+            }
+        }
+
+        client.connectPubSub().apply {
+            addListener(listener)
+            sync().subscribe("socket.io#/#")
+        }
+
+        publisher.broadcast("topic", "test 123")
+
+        countDownLatch.await(5, TimeUnit.SECONDS).shouldBeTrue()
+    }
+}

--- a/src/test/kotlin/de/smartsquare/socketio/emitter/SpringDataPublisherTest.kt
+++ b/src/test/kotlin/de/smartsquare/socketio/emitter/SpringDataPublisherTest.kt
@@ -1,0 +1,65 @@
+package de.smartsquare.socketio.emitter
+
+import com.redis.testcontainers.RedisContainer
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.connection.Message
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@Testcontainers
+class SpringDataPublisherTest {
+
+    @Container
+    private val redis = RedisContainer("redis:6-alpine")
+
+    private lateinit var lettuceConnectionFactory: LettuceConnectionFactory
+    private lateinit var template: StringRedisTemplate
+
+    @BeforeEach
+    fun setUp() {
+        lettuceConnectionFactory = LettuceConnectionFactory(redis.host, redis.firstMappedPort).apply {
+            afterPropertiesSet()
+        }
+
+        template = StringRedisTemplate().apply {
+            connectionFactory = lettuceConnectionFactory
+            afterPropertiesSet()
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        lettuceConnectionFactory.destroy()
+    }
+
+    @Test
+    fun `publish string message`() {
+        val publisher = Emitter(SpringDataPublisher(template))
+
+        val countDownLatch = CountDownLatch(1)
+
+        val messageListener = { message: Message, _: ByteArray? ->
+            message.channel.decodeToString() shouldBeEqualTo "socket.io#/#"
+            message.body.decodeToString() shouldContain "test 123"
+
+            countDownLatch.countDown()
+        }
+
+        template.requiredConnectionFactory.connection.also {
+            it.subscribe(messageListener, "socket.io#/#".toByteArray())
+        }
+
+        publisher.broadcast("topic", "test 123")
+
+        countDownLatch.await(5, TimeUnit.SECONDS).shouldBeTrue()
+    }
+}

--- a/src/test/kotlin/de/smartsquare/socketio/emitter/TestUtils.kt
+++ b/src/test/kotlin/de/smartsquare/socketio/emitter/TestUtils.kt
@@ -1,5 +1,43 @@
 package de.smartsquare.socketio.emitter
 
+import io.lettuce.core.RedisClient
+import io.lettuce.core.pubsub.RedisPubSubAdapter
+import org.amshove.kluent.shouldBeTrue
 import org.skyscreamer.jsonassert.JSONAssert
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 infix fun String.shouldBeEqualToJson(expected: String): String = apply { JSONAssert.assertEquals(expected, this, true) }
+
+/**
+ * Returns the first message published on the given [channel] of the redis available under the [redisURI]. Waits for at
+ * most five seconds after executing [body] for the message to arrive.
+ */
+fun awaitRedisMessage(redisURI: String, channel: String, body: () -> Unit): RedisMessage {
+    return RedisClient.create(redisURI).use { client ->
+        var result: RedisMessage? = null
+
+        val countDownLatch = CountDownLatch(1)
+
+        val listener = object : RedisPubSubAdapter<String, String>() {
+            override fun message(channel: String, message: String) {
+                result = RedisMessage(channel, message)
+
+                countDownLatch.countDown()
+            }
+        }
+
+        client.connectPubSub().apply {
+            addListener(listener)
+            sync().subscribe(channel)
+        }
+
+        body()
+
+        countDownLatch.await(5, TimeUnit.SECONDS).shouldBeTrue()
+
+        result!!
+    }
+}
+
+data class RedisMessage(val channel: String, val message: String)

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <!-- The following logger can be used for containers logs since 1.18.0 -->
+    <logger name="tc" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
+</configuration>


### PR DESCRIPTION
This adds support for publishing via the `RedisTemplate` from Spring Data Redis. `spring-boot-starter-data-redis` is added as a `compileOnly` dependency and thus is not required by consumers which do not use it.

Additionally, the `LettucePublisher` now takes  `RedisCommands` instead of a `StatefulRedisConnection`. That is better from what I understand since that is what you actually are supposed to run api calls on. `StatefulRedisConnection` is one of multiple options depending on the type of redis instance you are connecting to (there also exists `StatefulRedisClusterConnection` for example). This is a breaking change but you couldn't use the publisher before anyways since the generics were `<Any, Any>` which is impossible to satisfy so it should be fine.

Lastly, I added tests for all publishers with a real redis instance using testcontainers.